### PR TITLE
Fix $this being used instead of Auth:user()

### DIFF
--- a/src/CurrentLogin.php
+++ b/src/CurrentLogin.php
@@ -26,7 +26,7 @@ class CurrentLogin
 
             } elseif (Config::get('logins.sanctum_token_tracking') && Auth::user()->isAuthenticatedBySanctumToken()) {
 
-                $this->currentLogin = $this->logins()
+                $this->currentLogin = Auth::user()->logins()
                     ->where('personal_access_token_id', Auth::user()->currentAccessToken()->getKey())
                     ->first();
 


### PR DESCRIPTION
This PR fixes the additional issue I experienced in #4. 

`logins()` is not a function on the `CurrentLogin` class, and I assume the intention here was to use `Auth::user()`,  like the rest of this function does. 