### PR TITLE
Add a logins page in user settings for the new Laravel Livewire Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _____
   * [Configure the authentication guard](#configure-the-authentication-guard)
   * [Configure the user provider](#configure-the-user-provider)
   * [Laravel Sanctum](#laravel-sanctum)
+  * [Laravel Livewire Starter Kit](#laravel-livewire-starter-kit)
   * [Laravel Jetstream](#laravel-jetstream)
 * [Usage](#usage)
   * [Retrieving the logins](#retrieving-the-logins)
@@ -129,7 +130,7 @@ In your `auth.php` configuration file, use the `logins` driver in the user provi
 'providers' => [
     'users' => [
         'driver' => 'logins',
-        'model' => App\Models\User::class,
+        'model' => env('AUTH_MODEL', User::class),
     ],
     
     // ...
@@ -160,9 +161,53 @@ configuration file, and only the tokens whose name matches the defined pattern w
 'sanctum_token_name_regex' => '/^mobile_app_/',
 ```
 
+### Laravel Livewire Starter Kit
+
+If your application uses the official Laravel Livewire starter kit (Flux UI), running `php artisan logins:install`
+will also generate a reusable settings page for logins management.
+
+The installer auto-detects your starter kit variant and installs matching files:
+
+- **Single-file variant**:
+  - Copy `stubs/livewire-starter-kit/resources/views/pages/settings/⚡logins.blade.php` to `resources/views/pages/settings/⚡logins.blade.php`
+  - Add route `Route::livewire('settings/logins', 'pages::settings.logins')->name('logins.show');`
+  - Add `Logins` nav item in `resources/views/pages/settings/layout.blade.php`
+- **Class-based variant**:
+  - Copy `stubs/livewire-starter-kit-class-based/app/Livewire/Settings/Logins.php` to `app/Livewire/Settings/Logins.php`
+  - Copy `stubs/livewire-starter-kit-class-based/resources/views/livewire/settings/logins.blade.php` to `resources/views/livewire/settings/logins.blade.php`
+  - Add `use App\Livewire\Settings\Logins;` in `routes/settings.php`
+  - Add route `Route::livewire('settings/logins', Logins::class)->name('logins.show');`
+  - Add `Logins` nav item in `resources/views/components/settings/layout.blade.php`
+
+For both variants, if `config/logins.php` exists and `security_page_route` is still `null`, it is updated to `logins.show`.
+
+Use `php artisan logins:install --force` to overwrite generated UI files.
+
+If your app has heavily customized settings files and cannot be auto-updated, add these lines manually:
+
+```php
+Route::livewire('settings/logins', 'pages::settings.logins')->name('logins.show');
+```
+
+or (class-based variant):
+
+```php
+use App\Livewire\Settings\Logins;
+
+Route::livewire('settings/logins', Logins::class)->name('logins.show');
+```
+
+```blade
+<flux:navlist.item :href="route('logins.show')" wire:navigate>{{ __('Logins') }}</flux:navlist.item>
+```
+
+```php
+'security_page_route' => 'logins.show',
+```
+
 ### Laravel Jetstream
 
-If using Laravel Jetstream, you can stop using the `AuthenticateSession` middleware, as it is not necessary with Logins.
+If using the previous Livewire starter kit (Laravel Jetstream), you can stop using the `AuthenticateSession` middleware, as it is not necessary with Logins.
 
 In your `jetstream.php` configuration file, set `auth_session` to `null`:
 

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -14,7 +14,7 @@ class Install extends Command
      *
      * @var string
      */
-    protected $signature = 'logins:install';
+    protected $signature = 'logins:install {--force : Overwrite generated UI files}';
 
     /**
      * The console command description.
@@ -55,21 +55,190 @@ class Install extends Command
 
             $this->call('migrate', $options);
 
+            $filesystem = new Filesystem();
+
             if (
                 Helpers::jetstreamIsInstalled()
                 && Helpers::livewireIsInstalled()
                 && Config::get('jetstream.stack') === 'livewire'
             ) {
-                $this->comment('Creating files for Jetstream with Livewire stack...' . "\n");
+                $this->installJetstreamLivewireStackFiles($filesystem);
+            }
 
-                (new Filesystem)->ensureDirectoryExists(app_path('Livewire'));
-                (new Filesystem)->ensureDirectoryExists(resource_path('views/livewire'));
-
-                copy(__DIR__.'/../../stubs/jetstream-livewire/app/Livewire/Logins.php', app_path('Livewire/Logins.php'));
-                copy(__DIR__.'/../../stubs/jetstream-livewire/resources/views/livewire/logins.blade.php', resource_path('views/livewire/logins.blade.php'));
+            if (Helpers::livewireStarterKitClassBasedVariantIsInstalled()) {
+                $this->installLivewireStarterKitClassBasedVariantFiles($filesystem);
+            } elseif (Helpers::livewireStarterKitSingleFileVariantIsInstalled()) {
+                $this->installLivewireStarterKitSingleFileVariantFiles($filesystem);
             }
 
             $this->info('Installation was successful!');
         }
+    }
+
+    /**
+     * Install Jetstream (Livewire stack) component files.
+     */
+    protected function installJetstreamLivewireStackFiles(Filesystem $filesystem): void
+    {
+        $this->comment('Creating files for Jetstream with Livewire stack...' . "\n");
+
+        $filesystem->ensureDirectoryExists(app_path('Livewire'));
+        $filesystem->ensureDirectoryExists(resource_path('views/livewire'));
+
+        $this->copyStubFile(
+            __DIR__.'/../../stubs/jetstream-livewire/app/Livewire/Logins.php',
+            app_path('Livewire/Logins.php')
+        );
+
+        $this->copyStubFile(
+            __DIR__.'/../../stubs/jetstream-livewire/resources/views/livewire/logins.blade.php',
+            resource_path('views/livewire/logins.blade.php')
+        );
+    }
+
+    /**
+     * Install Laravel Livewire Starter Kit (single-file variant) settings page files.
+     */
+    protected function installLivewireStarterKitSingleFileVariantFiles(Filesystem $filesystem): void
+    {
+        $this->comment('Creating files for Laravel Livewire Starter Kit (single-file variant)...' . "\n");
+
+        $filesystem->ensureDirectoryExists(resource_path('views/pages/settings'));
+
+        $this->copyStubFile(
+            __DIR__.'/../../stubs/livewire-starter-kit/resources/views/pages/settings/⚡logins.blade.php',
+            resource_path('views/pages/settings/⚡logins.blade.php'),
+            (bool) $this->option('force')
+        );
+
+        $this->insertLineInFile(
+            base_path('routes/settings.php'),
+            "Route::livewire('settings/logins', 'pages::settings.logins')->name('logins.show');",
+            "    Route::livewire('settings/logins', 'pages::settings.logins')->name('logins.show');\n",
+            "    Route::livewire('settings/password', 'pages::settings.password')->name('user-password.edit');\n"
+        );
+
+        $this->insertLineInFile(
+            resource_path('views/pages/settings/layout.blade.php'),
+            "route('logins.show')",
+            "            <flux:navlist.item :href=\"route('logins.show')\" wire:navigate>{{ __('Logins') }}</flux:navlist.item>\n",
+            "            <flux:navlist.item :href=\"route('user-password.edit')\" wire:navigate>{{ __('Password') }}</flux:navlist.item>\n"
+        );
+
+        $this->setLivewireStarterKitSecurityRoute();
+    }
+
+    /**
+     * Install Laravel Livewire Starter Kit (class-based variant) settings page files.
+     */
+    protected function installLivewireStarterKitClassBasedVariantFiles(Filesystem $filesystem): void
+    {
+        $this->comment('Creating files for Laravel Livewire Starter Kit (class-based variant)...' . "\n");
+
+        $filesystem->ensureDirectoryExists(app_path('Livewire/Settings'));
+        $filesystem->ensureDirectoryExists(resource_path('views/livewire/settings'));
+
+        $this->copyStubFile(
+            __DIR__.'/../../stubs/livewire-starter-kit-class-based/app/Livewire/Settings/Logins.php',
+            app_path('Livewire/Settings/Logins.php'),
+            (bool) $this->option('force')
+        );
+
+        $this->copyStubFile(
+            __DIR__.'/../../stubs/livewire-starter-kit-class-based/resources/views/livewire/settings/logins.blade.php',
+            resource_path('views/livewire/settings/logins.blade.php'),
+            (bool) $this->option('force')
+        );
+
+        $this->insertLineInFile(
+            base_path('routes/settings.php'),
+            'use App\\Livewire\\Settings\\Logins;',
+            "use App\\Livewire\\Settings\\Logins;\n",
+            "use App\\Livewire\\Settings\\Appearance;\n"
+        );
+
+        $this->insertLineInFile(
+            base_path('routes/settings.php'),
+            "Route::livewire('settings/logins', Logins::class)->name('logins.show');",
+            "    Route::livewire('settings/logins', Logins::class)->name('logins.show');\n",
+            "    Route::livewire('settings/password', Password::class)->name('user-password.edit');\n"
+        );
+
+        $this->insertLineInFile(
+            resource_path('views/components/settings/layout.blade.php'),
+            "route('logins.show')",
+            "            <flux:navlist.item :href=\"route('logins.show')\" wire:navigate>{{ __('Logins') }}</flux:navlist.item>\n",
+            "            <flux:navlist.item :href=\"route('user-password.edit')\" wire:navigate>{{ __('Password') }}</flux:navlist.item>\n"
+        );
+
+        $this->setLivewireStarterKitSecurityRoute();
+    }
+
+    /**
+     * Copy a stub file, optionally skipping existing destination.
+     */
+    protected function copyStubFile(string $source, string $destination, bool $overwrite = true): void
+    {
+        if (file_exists($destination) && ! $overwrite) {
+            $this->line(sprintf('Skipping existing file [%s]. Use --force to overwrite it.', $destination));
+
+            return;
+        }
+
+        copy($source, $destination);
+    }
+
+    /**
+     * Insert a line in a file after a known existing line.
+     */
+    protected function insertLineInFile(string $path, string $contains, string $line, string $insertAfter): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false || str_contains($contents, $contains)) {
+            return;
+        }
+
+        if (str_contains($contents, $insertAfter)) {
+            file_put_contents($path, str_replace($insertAfter, $insertAfter.$line, $contents));
+
+            return;
+        }
+
+        $this->warn(sprintf('Could not auto update [%s]. Please add this manually.', $path));
+    }
+
+    /**
+     * Set security page route for Livewire Starter Kit if config is publishable.
+     */
+    protected function setLivewireStarterKitSecurityRoute(): void
+    {
+        $path = config_path('logins.php');
+
+        if (! file_exists($path)) {
+            return;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false || str_contains($contents, "'security_page_route' => 'logins.show',")) {
+            return;
+        }
+
+        $updatedContents = str_replace(
+            "'security_page_route' => null,",
+            "'security_page_route' => 'logins.show',",
+            $contents
+        );
+
+        if ($updatedContents === $contents) {
+            return;
+        }
+
+        file_put_contents($path, $updatedContents);
     }
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -27,4 +27,37 @@ class Helpers
     {
         return is_dir(base_path('vendor/livewire'));
     }
+
+    /**
+     * Check if Laravel Livewire Starter Kit is installed.
+     */
+    public static function livewireStarterKitIsInstalled(): bool
+    {
+        return self::livewireStarterKitSingleFileVariantIsInstalled()
+            || self::livewireStarterKitClassBasedVariantIsInstalled();
+    }
+
+    /**
+     * Check if Laravel Livewire Starter Kit (single-file component variant) is installed.
+     */
+    public static function livewireStarterKitSingleFileVariantIsInstalled(): bool
+    {
+        return self::livewireIsInstalled()
+            && is_dir(base_path('vendor/livewire/flux'))
+            && is_file(base_path('routes/settings.php'))
+            && is_file(resource_path('views/pages/settings/layout.blade.php'));
+    }
+
+    /**
+     * Check if Laravel Livewire Starter Kit (class-based variant) is installed.
+     */
+    public static function livewireStarterKitClassBasedVariantIsInstalled(): bool
+    {
+        return self::livewireIsInstalled()
+            && is_dir(base_path('vendor/livewire/flux'))
+            && is_file(base_path('routes/settings.php'))
+            && is_file(app_path('Livewire/Settings/Profile.php'))
+            && is_file(resource_path('views/livewire/settings/profile.blade.php'))
+            && is_file(resource_path('views/components/settings/layout.blade.php'));
+    }
 }

--- a/stubs/livewire-starter-kit-class-based/app/Livewire/Settings/Logins.php
+++ b/stubs/livewire-starter-kit-class-based/app/Livewire/Settings/Logins.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Login settings')]
+class Logins extends Component
+{
+    public string $password = '';
+
+    public bool $showDisconnectAllModal = false;
+
+    public bool $showDisconnectLoginModal = false;
+
+    #[Locked]
+    public ?int $selectedLoginId = null;
+
+    /**
+     * Get the authenticated user's tracked logins.
+     *
+     * @return Collection<int, \ALajusticia\Logins\Models\Login>
+     */
+    #[Computed]
+    public function logins(): Collection
+    {
+        return Auth::user()->logins()->latest('last_activity_at')->get();
+    }
+
+    /**
+     * Open the confirmation modal to disconnect all devices.
+     */
+    public function confirmDisconnectAllDevices(): void
+    {
+        $this->resetErrorBag();
+        $this->password = '';
+        $this->showDisconnectAllModal = true;
+    }
+
+    /**
+     * Open the confirmation modal for a specific login.
+     */
+    public function confirmDisconnectLogin(int $loginId): void
+    {
+        $login = Auth::user()->logins()->find($loginId);
+
+        abort_unless($login, 404);
+
+        $this->resetErrorBag();
+        $this->password = '';
+        $this->selectedLoginId = $login->id;
+        $this->showDisconnectLoginModal = true;
+    }
+
+    /**
+     * Close the "disconnect all devices" modal.
+     */
+    public function cancelDisconnectAllDevices(): void
+    {
+        $this->resetErrorBag();
+        $this->reset('password', 'showDisconnectAllModal');
+    }
+
+    /**
+     * Close the "disconnect selected device" modal.
+     */
+    public function cancelDisconnectLogin(): void
+    {
+        $this->resetErrorBag();
+        $this->reset('password', 'selectedLoginId', 'showDisconnectLoginModal');
+    }
+
+    /**
+     * Disconnect all tracked devices, including the current one.
+     */
+    public function disconnectAllDevices(): void
+    {
+        $this->validate([
+            'password' => ['required', 'string', 'current_password'],
+        ]);
+
+        Auth::user()->logoutAll();
+
+        $this->cancelDisconnectAllDevices();
+        $this->showDisconnectLoginModal = false;
+        $this->selectedLoginId = null;
+
+        $this->redirect(route('login', absolute: false), navigate: true);
+    }
+
+    /**
+     * Disconnect the selected device.
+     */
+    public function disconnectSelectedDevice(): void
+    {
+        $this->validate([
+            'password' => ['required', 'string', 'current_password'],
+        ]);
+
+        $selectedLogin = Auth::user()->logins()->find($this->selectedLoginId);
+
+        abort_unless($selectedLogin, 404);
+
+        $disconnectingCurrentDevice = $selectedLogin->is_current;
+
+        Auth::user()->logout($selectedLogin->id);
+
+        $this->cancelDisconnectLogin();
+
+        if ($disconnectingCurrentDevice) {
+            $this->redirect(route('login', absolute: false), navigate: true);
+
+            return;
+        }
+
+        $this->dispatch('logins-updated');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.settings.logins');
+    }
+}

--- a/stubs/livewire-starter-kit-class-based/resources/views/livewire/settings/logins.blade.php
+++ b/stubs/livewire-starter-kit-class-based/resources/views/livewire/settings/logins.blade.php
@@ -1,0 +1,144 @@
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <flux:heading class="sr-only">{{ __('Login settings') }}</flux:heading>
+
+    <x-settings.layout
+        :heading="__('Logins')"
+        :subheading="__('Manage devices and sessions signed in to your account')"
+    >
+        <div class="space-y-6">
+            <flux:text variant="subtle">
+                {{ __('Review your active devices and disconnect any sessions you no longer recognize or trust.') }}
+            </flux:text>
+
+            @if ($this->logins->isEmpty())
+                <flux:callout
+                    icon="information-circle"
+                    heading="{{ __('No active logins were found.') }}"
+                />
+            @else
+                <div class="space-y-3">
+                    @foreach ($this->logins as $login)
+                        <div
+                            wire:key="login-{{ $login->id }}"
+                            class="flex flex-col gap-4 rounded-xl border border-zinc-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex items-start gap-3">
+                                <div class="mt-0.5 text-zinc-500 dark:text-zinc-400">
+                                    @if ($login->device_type === 'desktop')
+                                        <flux:icon.computer-desktop variant="outline" class="size-5" />
+                                    @elseif ($login->device_type === 'tablet')
+                                        <flux:icon.device-tablet variant="outline" class="size-5" />
+                                    @else
+                                        <flux:icon.device-phone-mobile variant="outline" class="size-5" />
+                                    @endif
+                                </div>
+
+                                <div class="space-y-1">
+                                    <div class="flex items-center gap-2">
+                                        <flux:text class="font-medium text-zinc-900 dark:text-zinc-100">
+                                            {{ filled($login->label) ? $login->label : __('Unknown device') }}
+                                        </flux:text>
+
+                                        @if ($login->is_current)
+                                            <flux:badge color="green">
+                                                {{ __('This device') }}
+                                            </flux:badge>
+                                        @endif
+                                    </div>
+
+                                    <flux:text size="sm" variant="subtle">
+                                        {{ $login->ip_address ?: __('Unknown IP address') }}
+                                    </flux:text>
+
+                                    @if (! $login->is_current)
+                                        <flux:text size="sm" variant="subtle">
+                                            {{ __('Last active :time', ['time' => $login->last_active]) }}
+                                        </flux:text>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <flux:button
+                                variant="danger"
+                                size="sm"
+                                wire:click="confirmDisconnectLogin({{ $login->id }})"
+                            >
+                                {{ __('Disconnect') }}
+                            </flux:button>
+                        </div>
+                    @endforeach
+                </div>
+
+                <div class="flex items-center gap-3">
+                    <flux:button variant="danger" wire:click="confirmDisconnectAllDevices">
+                        {{ __('Disconnect all devices') }}
+                    </flux:button>
+
+                    <x-action-message on="logins-updated">
+                        {{ __('Updated.') }}
+                    </x-action-message>
+                </div>
+            @endif
+        </div>
+    </x-settings.layout>
+
+    <flux:modal wire:model="showDisconnectLoginModal" class="max-w-lg">
+        <form method="POST" wire:submit="disconnectSelectedDevice" class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Disconnect this device?') }}</flux:heading>
+
+                <flux:subheading>
+                    {{ __('Enter your password to confirm disconnecting this device session.') }}
+                </flux:subheading>
+            </div>
+
+            <flux:input
+                wire:model="password"
+                :label="__('Password')"
+                type="password"
+                autocomplete="current-password"
+            />
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="filled" type="button" wire:click="cancelDisconnectLogin">
+                    {{ __('Cancel') }}
+                </flux:button>
+
+                <flux:button variant="danger" type="submit">
+                    {{ __('Disconnect device') }}
+                </flux:button>
+            </div>
+        </form>
+    </flux:modal>
+
+    <flux:modal wire:model="showDisconnectAllModal" class="max-w-lg">
+        <form method="POST" wire:submit="disconnectAllDevices" class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Disconnect all devices?') }}</flux:heading>
+
+                <flux:subheading>
+                    {{ __('Enter your password to confirm. This will sign you out from every device, including this one.') }}
+                </flux:subheading>
+            </div>
+
+            <flux:input
+                wire:model="password"
+                :label="__('Password')"
+                type="password"
+                autocomplete="current-password"
+            />
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="filled" type="button" wire:click="cancelDisconnectAllDevices">
+                    {{ __('Cancel') }}
+                </flux:button>
+
+                <flux:button variant="danger" type="submit">
+                    {{ __('Disconnect all devices') }}
+                </flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</section>

--- a/stubs/livewire-starter-kit/resources/views/pages/settings/⚡logins.blade.php
+++ b/stubs/livewire-starter-kit/resources/views/pages/settings/⚡logins.blade.php
@@ -1,0 +1,263 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('Login settings')] class extends Component {
+    public string $password = '';
+
+    public bool $showDisconnectAllModal = false;
+    public bool $showDisconnectLoginModal = false;
+
+    #[Locked]
+    public ?int $selectedLoginId = null;
+
+    /**
+     * Get the authenticated user's tracked logins.
+     *
+     * @return Collection<int, \ALajusticia\Logins\Models\Login>
+     */
+    #[Computed]
+    public function logins(): Collection
+    {
+        return Auth::user()->logins()->latest('last_activity_at')->get();
+    }
+
+    /**
+     * Open the confirmation modal to disconnect all devices.
+     */
+    public function confirmDisconnectAllDevices(): void
+    {
+        $this->resetErrorBag();
+        $this->password = '';
+        $this->showDisconnectAllModal = true;
+    }
+
+    /**
+     * Open the confirmation modal for a specific login.
+     */
+    public function confirmDisconnectLogin(int $loginId): void
+    {
+        $login = Auth::user()->logins()->find($loginId);
+
+        abort_unless($login, 404);
+
+        $this->resetErrorBag();
+        $this->password = '';
+        $this->selectedLoginId = $login->id;
+        $this->showDisconnectLoginModal = true;
+    }
+
+    /**
+     * Close the "disconnect all devices" modal.
+     */
+    public function cancelDisconnectAllDevices(): void
+    {
+        $this->resetErrorBag();
+        $this->reset('password', 'showDisconnectAllModal');
+    }
+
+    /**
+     * Close the "disconnect selected device" modal.
+     */
+    public function cancelDisconnectLogin(): void
+    {
+        $this->resetErrorBag();
+        $this->reset('password', 'selectedLoginId', 'showDisconnectLoginModal');
+    }
+
+    /**
+     * Disconnect all tracked devices, including the current one.
+     */
+    public function disconnectAllDevices(): void
+    {
+        $this->validate([
+            'password' => ['required', 'string', 'current_password'],
+        ]);
+
+        Auth::user()->logoutAll();
+
+        $this->cancelDisconnectAllDevices();
+        $this->showDisconnectLoginModal = false;
+        $this->selectedLoginId = null;
+
+        $this->redirect(route('login', absolute: false), navigate: true);
+    }
+
+    /**
+     * Disconnect the selected device.
+     */
+    public function disconnectSelectedDevice(): void
+    {
+        $this->validate([
+            'password' => ['required', 'string', 'current_password'],
+        ]);
+
+        $selectedLogin = Auth::user()->logins()->find($this->selectedLoginId);
+
+        abort_unless($selectedLogin, 404);
+
+        $disconnectingCurrentDevice = $selectedLogin->is_current;
+
+        Auth::user()->logout($selectedLogin->id);
+
+        $this->cancelDisconnectLogin();
+
+        if ($disconnectingCurrentDevice) {
+            $this->redirect(route('login', absolute: false), navigate: true);
+
+            return;
+        }
+
+        $this->dispatch('logins-updated');
+    }
+}; ?>
+
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <flux:heading class="sr-only">{{ __('Login settings') }}</flux:heading>
+
+    <x-pages::settings.layout
+        :heading="__('Logins')"
+        :subheading="__('Manage devices and sessions signed in to your account')"
+    >
+        <div class="space-y-6">
+            <flux:text variant="subtle">
+                {{ __('Review your active devices and disconnect any sessions you no longer recognize or trust.') }}
+            </flux:text>
+
+            @if ($this->logins->isEmpty())
+                <flux:callout
+                    icon="information-circle"
+                    heading="{{ __('No active logins were found.') }}"
+                />
+            @else
+                <div class="space-y-3">
+                    @foreach ($this->logins as $login)
+                        <div
+                            wire:key="login-{{ $login->id }}"
+                            class="flex flex-col gap-4 rounded-xl border border-zinc-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex items-start gap-3">
+                                <div class="mt-0.5 text-zinc-500 dark:text-zinc-400">
+                                    @if ($login->device_type === 'desktop')
+                                        <flux:icon.computer-desktop variant="outline" class="size-5" />
+                                    @elseif ($login->device_type === 'tablet')
+                                        <flux:icon.device-tablet variant="outline" class="size-5" />
+                                    @else
+                                        <flux:icon.device-phone-mobile variant="outline" class="size-5" />
+                                    @endif
+                                </div>
+
+                                <div class="space-y-1">
+                                    <div class="flex items-center gap-2">
+                                        <flux:text class="font-medium text-zinc-900 dark:text-zinc-100">
+                                            {{ filled($login->label) ? $login->label : __('Unknown device') }}
+                                        </flux:text>
+
+                                        @if ($login->is_current)
+                                            <flux:badge color="green">
+                                                {{ __('This device') }}
+                                            </flux:badge>
+                                        @endif
+                                    </div>
+
+                                    <flux:text size="sm" variant="subtle">
+                                        {{ $login->ip_address ?: __('Unknown IP address') }}
+                                    </flux:text>
+
+                                    @if (! $login->is_current)
+                                        <flux:text size="sm" variant="subtle">
+                                            {{ __('Last active :time', ['time' => $login->last_active]) }}
+                                        </flux:text>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <flux:button
+                                variant="danger"
+                                size="sm"
+                                wire:click="confirmDisconnectLogin({{ $login->id }})"
+                            >
+                                {{ __('Disconnect') }}
+                            </flux:button>
+                        </div>
+                    @endforeach
+                </div>
+
+                <div class="flex items-center gap-3">
+                    <flux:button variant="danger" wire:click="confirmDisconnectAllDevices">
+                        {{ __('Disconnect all devices') }}
+                    </flux:button>
+
+                    <x-action-message on="logins-updated">
+                        {{ __('Updated.') }}
+                    </x-action-message>
+                </div>
+            @endif
+        </div>
+    </x-pages::settings.layout>
+
+    <flux:modal wire:model="showDisconnectLoginModal" class="max-w-lg">
+        <form method="POST" wire:submit="disconnectSelectedDevice" class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Disconnect this device?') }}</flux:heading>
+
+                <flux:subheading>
+                    {{ __('Enter your password to confirm disconnecting this device session.') }}
+                </flux:subheading>
+            </div>
+
+            <flux:input
+                wire:model="password"
+                :label="__('Password')"
+                type="password"
+                autocomplete="current-password"
+            />
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="filled" type="button" wire:click="cancelDisconnectLogin">
+                    {{ __('Cancel') }}
+                </flux:button>
+
+                <flux:button variant="danger" type="submit">
+                    {{ __('Disconnect device') }}
+                </flux:button>
+            </div>
+        </form>
+    </flux:modal>
+
+    <flux:modal wire:model="showDisconnectAllModal" class="max-w-lg">
+        <form method="POST" wire:submit="disconnectAllDevices" class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Disconnect all devices?') }}</flux:heading>
+
+                <flux:subheading>
+                    {{ __('Enter your password to confirm. This will sign you out from every device, including this one.') }}
+                </flux:subheading>
+            </div>
+
+            <flux:input
+                wire:model="password"
+                :label="__('Password')"
+                type="password"
+                autocomplete="current-password"
+            />
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="filled" type="button" wire:click="cancelDisconnectAllDevices">
+                    {{ __('Cancel') }}
+                </flux:button>
+
+                <flux:button variant="danger" type="submit">
+                    {{ __('Disconnect all devices') }}
+                </flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</section>

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ALajusticia\Logins\Tests;
+
+use ALajusticia\Logins\Helpers;
+
+class HelpersTest extends TestCase
+{
+    public function test_detect_livewire_starter_kit_single_file_variant()
+    {
+        $fluxPath = base_path('vendor/livewire/flux/.gitkeep');
+        $settingsRoutesPath = base_path('routes/settings.php');
+        $singleFileSettingsLayoutPath = resource_path('views/pages/settings/layout.blade.php');
+
+        $this->createFile($fluxPath, '');
+        $this->createFile($settingsRoutesPath, "<?php\n");
+        $this->createFile($singleFileSettingsLayoutPath, '<div></div>');
+
+        $this->assertTrue(Helpers::livewireStarterKitSingleFileVariantIsInstalled());
+        $this->assertTrue(Helpers::livewireStarterKitIsInstalled());
+
+        unlink($singleFileSettingsLayoutPath);
+
+        $this->assertFalse(Helpers::livewireStarterKitSingleFileVariantIsInstalled());
+    }
+
+    public function test_detect_livewire_starter_kit_class_based_variant()
+    {
+        $fluxPath = base_path('vendor/livewire/flux/.gitkeep');
+        $settingsRoutesPath = base_path('routes/settings.php');
+        $classBasedProfileClassPath = app_path('Livewire/Settings/Profile.php');
+        $classBasedProfileViewPath = resource_path('views/livewire/settings/profile.blade.php');
+        $classBasedSettingsLayoutPath = resource_path('views/components/settings/layout.blade.php');
+
+        $this->createFile($fluxPath, '');
+        $this->createFile($settingsRoutesPath, "<?php\n");
+        $this->createFile($classBasedProfileClassPath, "<?php\n");
+        $this->createFile($classBasedProfileViewPath, '<div></div>');
+        $this->createFile($classBasedSettingsLayoutPath, '<div></div>');
+
+        $this->assertTrue(Helpers::livewireStarterKitClassBasedVariantIsInstalled());
+        $this->assertTrue(Helpers::livewireStarterKitIsInstalled());
+
+        unlink($classBasedProfileClassPath);
+
+        $this->assertFalse(Helpers::livewireStarterKitClassBasedVariantIsInstalled());
+    }
+
+    protected function createFile(string $path, string $content): void
+    {
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+
+        file_put_contents($path, $content);
+    }
+}


### PR DESCRIPTION
- support for both variants (detect single-file and class-based structures)
- `logins:install` artisan command: add `--force` option to overwrite generated UI files
- add helper tests for variant detection